### PR TITLE
Fix usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ for (var i = 0; i < 1000; i++) {
   digest.Add(i);
 }
 digest.Cdf(244); // To get the percentile of any value.
-digest.Quantile(99); // To get the value of a specific percentile.
+digest.Quantile(0.99); // To get the value of a specific percentile.
 ```


### PR DESCRIPTION
digest.Quantile(99) throws a System.ArgumentException with message "q should be in [0,1], got 99". The example seems to assume a percentile, rather than a quantile, is required.